### PR TITLE
Expose the prefer-const-values option via the CLI

### DIFF
--- a/packages/quicktype-core/src/language/TypeScriptFlow.ts
+++ b/packages/quicktype-core/src/language/TypeScriptFlow.ts
@@ -51,7 +51,8 @@ export abstract class TypeScriptFlowBaseTargetLanguage extends JavaScriptTargetL
             tsFlowOptions.converters,
             tsFlowOptions.rawType,
             tsFlowOptions.preferUnions,
-            tsFlowOptions.preferTypes
+            tsFlowOptions.preferTypes,
+            tsFlowOptions.preferConstValues
         ];
     }
 


### PR DESCRIPTION
Expose the `prefer-const-values` typescriptFlow option via the CLI